### PR TITLE
SmallVector: Check if we need to switch to dynamic memory when calling create()

### DIFF
--- a/ea_data_structures/Structures/SmallVector.h
+++ b/ea_data_structures/Structures/SmallVector.h
@@ -98,6 +98,8 @@ struct SmallVector: VectorBase
     template <typename... Args>
     T& create(Args&&... args)
     {
+        checkSwitch(1);
+
         if (isStatic())
             return staticVec.create(std::forward<Args>(args)...);
 


### PR DESCRIPTION
Previously, calling `SmallVector::create()` or `SmallVector::emplace_back()` would stop adding elements to the vector once the static memory had been maxed out.